### PR TITLE
Added "init" param support to loadouts

### DIFF
--- a/f/assignGear/fn_assignGearMan.sqf
+++ b/f/assignGear/fn_assignGearMan.sqf
@@ -179,4 +179,9 @@ if ((count _handguns) > 0) then {_unit addWeapon (_handguns call BIS_fnc_selectR
             systemChat format ["Failed To add Magazine %1 to %2", _x, _loadout];
         };
     };
-} forEach _magazinesNotAdded
+} forEach _magazinesNotAdded;
+
+_a = _path >> "init";
+if (isText _a) then {
+	_unit call compile ("this = _this;"+ getText _a);
+};


### PR DESCRIPTION
*Updated to latest version of " f/assignGear/fn_assignGearMan.sqf"*

Allows initialization code to be defined in CfgLoadouts.hpp. Unit that loadout is being added to is passed as a variable called "this" (same as editor initialization).

loadout example:
class loadout123 {
    init = "hint 'You have a special loadout'; [this,45,12] call BIS_fnc_setPitchBank";
}